### PR TITLE
Controlling goroutine lifecycle

### DIFF
--- a/hagentserver.go
+++ b/hagentserver.go
@@ -18,15 +18,21 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"math"
 	"net"
+	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/coreos/go-systemd/activation"
@@ -68,40 +74,57 @@ func getCPUSample() (idle, total int64, err error) {
 	return
 }
 
-func calculateHealth(milliseconds int) {
+func updateHealthMetrics() error {
+	idle, total, err := getCPUSample()
+	if err != nil {
+		return errors.New("Failed to read /proc/stats")
+	}
+	idleTicks := float64(idle - atomic.LoadInt64(&lastIdle))
+	totalTicks := float64(total - atomic.LoadInt64(&lastTotal))
+	cpuUsage := float64(0.0)
+	if totalTicks > 0 {
+		cpuUsage = 100 * ((totalTicks - idleTicks) / totalTicks)
+	}
+
+	haproxyHealth := int32(math.Floor(100 - cpuUsage))
+
+	// ensure we do not drain nodes...
+	if haproxyHealth <= 0 {
+		haproxyHealth = 1
+	}
+
+	atomic.StoreInt64(&lastIdle, idle)
+	atomic.StoreInt64(&lastTotal, total)
+	atomic.StoreInt32(&lastHealth, haproxyHealth)
+	return nil
+}
+
+func calculateHealth(ctx context.Context, milliseconds int) {
+	ticker := time.NewTicker(time.Duration(milliseconds) * time.Millisecond)
 	for {
-		idle, total, err := getCPUSample()
-		if err != nil {
-			log.Fatal("Failed to read /proc/stats")
-			continue
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
 		}
-		idleTicks := float64(idle - atomic.LoadInt64(&lastIdle))
-		totalTicks := float64(total - atomic.LoadInt64(&lastTotal))
-		cpuUsage := float64(0.0)
-		if totalTicks > 0 {
-			cpuUsage = 100 * ((totalTicks - idleTicks) / totalTicks)
+		if err := updateHealthMetrics(); err != nil {
+			log.Fatalf("Failed to update metrics: %s", err.Error())
 		}
-
-		haproxyHealth := int32(math.Floor(100 - cpuUsage))
-
-		// ensure we do not drain nodes...
-		if haproxyHealth <= 0 {
-			haproxyHealth = 1
-		}
-
-		atomic.StoreInt64(&lastIdle, idle)
-		atomic.StoreInt64(&lastTotal, total)
-		atomic.StoreInt32(&lastHealth, haproxyHealth)
-		time.Sleep(time.Duration(milliseconds) * time.Millisecond)
 	}
 }
 
-func clientConnections(listener net.Listener) chan net.Conn {
+func clientConnections(ctx context.Context, listener net.Listener) chan net.Conn {
 	ch := make(chan net.Conn)
 	go func() {
 		for {
+			select {
+			case <-ctx.Done():
+				defer close(ch)
+				return
+			default:
+			}
 			client, err := listener.Accept()
-			if client == nil {
+			if err != nil {
 				log.Fatalf("Failed to accept: %s", err.Error())
 				continue
 			}
@@ -111,9 +134,13 @@ func clientConnections(listener net.Listener) chan net.Conn {
 	return ch
 }
 
-func handleConnection(client net.Conn, logRequests bool) {
+func buildStatusMessage() string {
 	health := atomic.LoadInt32(&lastHealth)
-	readyness := fmt.Sprintf("%d%% ready", health)
+	return fmt.Sprintf("%d%% ready", health)
+}
+
+func handleConnection(client net.Conn, logRequests bool) {
+	readyness := buildStatusMessage()
 	if logRequests {
 		log.Println(client.RemoteAddr(), readyness)
 	}
@@ -125,41 +152,110 @@ func handleConnection(client net.Conn, logRequests bool) {
 	}
 }
 
+func runTCPListener(listener net.Listener, logRequests bool, refreshInterval int) error {
+	sigChan := make(chan os.Signal, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	defer func() {
+		wg.Wait()
+		close(sigChan)
+	}()
+
+	signal.Notify(sigChan, syscall.SIGINT)
+
+	wg.Add(1)
+	go func() {
+		_, ok := <-sigChan
+		if !ok {
+			return
+		}
+		log.Println("SIGINT received. Exiting...")
+		cancel()
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		calculateHealth(ctx, refreshInterval)
+		wg.Done()
+	}()
+
+	connections := clientConnections(ctx, listener)
+connectionLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			break connectionLoop
+		case conn, open := <-connections:
+			if !open {
+				break connectionLoop
+			}
+			wg.Add(1)
+			go func() {
+				handleConnection(conn, logRequests)
+				wg.Done()
+			}()
+		}
+	}
+	return ctx.Err()
+}
+
 func main() {
-	debugPort := flag.Int("port", 7777, "tcp port to use (ignored if activated via systemd)")
-	timeframe := flag.Int("timeframe", 2000, "calculate cpu usage for this timeframe in milliseconds")
-	logRequests := flag.Bool("log-requests", false, "log each request with remote IP and returned health")
+	var useSystemd bool
+	var debugPort int
+	var logRequests bool
+	var timeframe int
+
+	flag.BoolVar(&useSystemd, "systemd", false, "Use systemd activation mechanism")
+	flag.IntVar(&debugPort, "port", 0, "tcp port to use (ignored if activated via systemd)")
+	flag.IntVar(&timeframe, "timeframe", 2000, "calculate cpu usage for this timeframe in milliseconds")
+	flag.BoolVar(&logRequests, "log-requests", false, "log each request with remote IP and returned health")
 	flag.Parse()
+
+	if useSystemd && debugPort != 0 {
+		log.Fatal("-systemd and -port are mutually exclusive.")
+	}
 
 	var tcpListener net.Listener
 	var err error
-	useSystemd := false
-
-	systemdListeners, err := activation.Listeners(true)
-	if err != nil {
-		log.Fatal("Failed to start systemd activation")
-	}
-	if len(systemdListeners) != 1 {
-		useSystemd = false
-	}
 
 	if useSystemd {
+		systemdListeners, err := activation.Listeners(true)
+		if err != nil {
+			log.Fatal("Failed to start systemd activation")
+		}
+		if len(systemdListeners) != 1 {
+			log.Fatal("No systemd activation listeners available")
+		}
 		log.Println("Using systemd activation")
 		tcpListener = systemdListeners[0]
-	} else {
-		log.Println("Using normal tcp port")
-		tcpListener, err = net.Listen("tcp", ":"+strconv.Itoa(*debugPort))
+	}
+
+	if debugPort != 0 {
+		tcpListener, err = net.Listen("tcp", ":"+strconv.Itoa(debugPort))
 		if tcpListener == nil {
 			log.Fatalf("Couldn't start a normal TCP listener: %s", err.Error())
 		}
-		log.Printf("Listening on port %d\n", *debugPort)
+		log.Printf("Listening on port %d\n", debugPort)
 	}
 
-	go calculateHealth(*timeframe)
-
-	connections := clientConnections(tcpListener)
-	for {
-		go handleConnection(<-connections, *logRequests)
+	// If we are operating as a server, we continually have to handle incoming
+	// connections and update the health status.
+	if useSystemd || debugPort != 0 {
+		if err := runTCPListener(tcpListener, logRequests, timeframe); err != nil {
+			if err != context.Canceled {
+				log.Fatalf("TCP listener failed: %s", err.Error())
+			}
+		}
+		tcpListener.Close()
+		return
 	}
 
+	// In the one-shot mode, we just update the metrics and print them to
+	// STDOUT.
+	if err := updateHealthMetrics(); err != nil {
+		log.Fatalf("Failed to update metrics: %s", err.Error())
+	}
+	fmt.Println(buildStatusMessage())
 }


### PR DESCRIPTION
Here we handle the lifecycle of each started goroutine explicitly and
also make things like what server mode should be used configurable
instead of relying on fallbacks.